### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,8 @@ init:
 	@if [ -f .env ]; then \
 		grep -q '^[^#]*=' .env || { echo ".envファイルに未設定の環境変数があります。すべての値を埋めてください。" ; exit 1; }; \
 	fi
-	make build
-	make up
+	${MAKE} build
+	${MAKE} up
 
 .PHONY: build
 build:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-include .env
+include .env.dev
 
 SRC_DIR=src
 MIGRATIONS_DIR=migrations
@@ -24,8 +24,8 @@ init:
 	@if [ -f .env ]; then \
 		grep -q '^[^#]*=' .env || { echo ".envファイルに未設定の環境変数があります。すべての値を埋めてください。" ; exit 1; }; \
 	fi
-	${make} build
-	${make} up
+	${MAKE} build
+	${MAKE} up
 
 .PHONY: build
 build:


### PR DESCRIPTION
modified some codes to build successfully.

- In initial, we have only `.env.dev` not `.env`, so returns 
`Makefile:1: .env: No such file or directory`

- To execute make command recursively, we need to use `${MAKE}`
`make` だと定義されていない変数扱いになるので、同ファイル内のコマンドを（再帰的に）使用するためには `${MAKE}` じゃないといけないらしい