### PR TITLE
Update: healthcheck rule of db container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,14 @@ else
 DOCKER_COMPOSE_IMPL=docker-compose
 endif
 
+.PHONY: cat
+cat:
+	cat Makefile
+
+.PHONY: help
+help:
+	${MAKE} cat
+
 .PHONY: cp/env
 cp/env:
 	cp .env.dev .env
@@ -77,6 +85,11 @@ rebuild/app:
 rebuild/db:
 	${DOCKER_COMPOSE_IMPL} build db
 	${DOCKER_COMPOSE_IMPL} up -d db
+
+.PHONY: rebuild/all
+rebuild/all:
+	${MAKE} rebuild/app
+	${MAKE} rebuild/db
 
 .PHONY: fmt
 fmt:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -24,11 +24,11 @@ services:
     platform: linux/x86_64
     image: mysql:8.0.29
     healthcheck:
-      test: [ "CMD", "mysqladmin", "ping", "-h", "localhost" ]
-      interval: 30s
+      test: mysqladmin ping -h 127.0.0.1 -u root
+      interval: 5s
       timeout: 5s
       retries: 5
-      start_period: 30s
+      start_period: 5s
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: "true"
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}


### PR DESCRIPTION
close #28 

# やったこと
- DB ContainerのHealthcheckのルールを変更した
- Makeコマンドの追加
  - rebuild/all
  - help
  - cat

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - Makefileに`cat`および`help`ターゲットを追加し、Makefileの内容表示と`cat`の呼び出しが可能に。

- **改善**
  - MySQLサービスの`healthcheck`設定を更新し、テストコマンドを簡略化し、チェック間隔と開始期間を短縮。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->